### PR TITLE
Update 07.1.md

### DIFF
--- a/zh/07.1.md
+++ b/zh/07.1.md
@@ -36,7 +36,7 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -54,13 +54,13 @@ type server struct {
 }
 
 func main() {
-	file, err := os.Open("servers.xml") // For read access.		
+	file, err := os.Open("servers.xml") // For read access.
 	if err != nil {
 		fmt.Printf("error: %v", err)
 		return
 	}
 	defer file.Close()
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		fmt.Printf("error: %v", err)
 		return


### PR DESCRIPTION
Ioutil is deprecated since Go 1.16, the same functionality is now provided by package io or package os.